### PR TITLE
Simplify Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: trusty
 language: node_js
 node_js:
   - 'lts/dubnium'
+before_install:
+  - npm install yarn
 script:
   - yarn run lint
   - yarn run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 dist: trusty
 language: node_js
 node_js:
-  - '7'
-before_install:
-  - nvm install lts/dubnium
-  - nvm use lts/dubnium
-  - npm install yarn
+  - 'lts/dubnium'
 script:
   - yarn run lint
   - yarn run test


### PR DESCRIPTION
The string in the `node_js` is used directly by the `nvm` installation during the build, so we can just use that rather than our own `nvm install` step.