### PR TITLE
 Add more info to most guide action types

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -4,7 +4,7 @@ export function toGuidelimeStep(classicWowStep: Array<string>): GuidelimeStep {
   const actionIdx = 1;
   const questIdIdx = 6;
   const amountIdx = 7;
-  const questNameIdx = 8; // location for set hearth
+  const questNameIdx = 8;
   const npcName = 9;
   const coordIdx = 12;
   const zone = 13;
@@ -22,19 +22,28 @@ export function toGuidelimeStep(classicWowStep: Array<string>): GuidelimeStep {
       .map(s => s.charAt(0).toUpperCase() + s.substring(1))
       .join(' ');
 
+  const sanitizeCoords = (coords: string): string => {
+    const xy = coords.split(',');
+    const x = (Number(xy[0]) || Number(xy[0].slice(1))).toFixed(1);
+    const y = (Number(xy[1]) || Number(xy[1].slice(1))).toFixed(1);
+    return [x, y].join(',');
+  };
+
   const coordsLine = (): string => {
     const coords = classicWowStep[coordIdx];
     if (coords === '') {
       return '';
     } else {
       const location = toTitleCaseNoDash(classicWowStep[zone]);
-      return `[G ${coords} ${location}]`;
+      return `[G ${sanitizeCoords(coords)} ${location}]`;
     }
   };
 
   const getAmount = (): string => {
     if (
-      (actionLine === 'Buy' || actionLine === 'Bank Deposit') &&
+      ['Buy', 'Bank Deposit', 'Bank Withdrawal', 'Save', 'Disenchant', 'Craft', 'Grind'].includes(
+        actionLine
+      ) &&
       classicWowStep[amountIdx] !== ''
     ) {
       return `(Qty: ${classicWowStep[amountIdx]})`;
@@ -43,9 +52,9 @@ export function toGuidelimeStep(classicWowStep: Array<string>): GuidelimeStep {
     }
   };
 
-  const trimSqBrackets = (str: string): string => {
-    return str.replace(/[[|\]]/g, '');
-  };
+  const trimSqBrackets = (str: string): string => str.replace(/[[|\]]/g, '');
+
+  const removeFirstWord = (str: string): string => str.replace(/^([^ ]+ )/, '');
 
   const questKeys = {
     'Hand In': 'T',
@@ -59,24 +68,34 @@ export function toGuidelimeStep(classicWowStep: Array<string>): GuidelimeStep {
     'Skip for now': 'S',
     Skip: 'S',
     'Complete Quest': 'C',
-  };
-
-  const hearth = (): string => {
-    if (actionLine === 'Set Hearth') {
-      const location = classicWowStep[questNameIdx].replace('at ', '');
-      return `[S ${location}]`;
-    } else if (actionLine === 'Hearth') {
-      const location = classicWowStep[questNameIdx].replace('to ', '');
-      return `[H ${location}]`;
-    } else {
-      return '';
-    }
+    'Complete Objective': 'C',
+    'Progress Quest': 'C',
+    'Progress Objective': 'C',
   };
 
   const getNpc = (): string => {
     if (classicWowStep[npcName] !== '') {
-      if (actionLine === 'Loot') {
-        return `from ${classicWowStep[npcName]}`;
+      if (
+        [
+          'Loot',
+          'Loot*',
+          'Get',
+          'Buy',
+          'Vendor',
+          'Repair',
+          'Vendor + Repair',
+          'Train',
+          'Bank Deposit',
+          'Bank Withdrawal',
+          'Hand In',
+          'Hand In*',
+          'Quick Hand In',
+          'Quick Hand In*',
+          'Pick Up',
+          'Pick Up*',
+        ].includes(actionLine)
+      ) {
+        return `(${classicWowStep[npcName]})`;
       } else if (actionLine === 'Tame') {
         return `${classicWowStep[npcName]}`;
       }
@@ -85,9 +104,13 @@ export function toGuidelimeStep(classicWowStep: Array<string>): GuidelimeStep {
   };
 
   const getObjective = (): string => {
-    if (actionLine === 'Complete Objective') {
+    if (
+      ['Complete Objective', 'Complete Quest', 'Progress Objective', 'Progress Quest'].includes(
+        actionLine
+      )
+    ) {
       const objective = trimSqBrackets(classicWowStep[npcName]);
-      return `(${objective})`;
+      return objective ? `(${objective})` : '';
     } else {
       return '';
     }
@@ -101,31 +124,80 @@ export function toGuidelimeStep(classicWowStep: Array<string>): GuidelimeStep {
     }
   };
 
+  const getGrindLine = (): string => {
+    const step = classicWowStep[questNameIdx];
+    const partialLevelRe = new RegExp('^to ([0-9]*) / ([0-9]*) L([0-9]*)$');
+    const fullLevelRe = new RegExp('^to ([0-9]*)$');
+
+    const partialLevelMatch = step.match(partialLevelRe);
+    if (partialLevelMatch) {
+      const [, numer, , lv] = partialLevelMatch;
+      return `to [XP${lv}+${numer} ${numer}xp into ${lv}]`;
+    }
+
+    const fullLevelMatch = step.match(fullLevelRe);
+    if (fullLevelMatch) {
+      const [, lv] = fullLevelMatch;
+      return `to [XP${lv}]`;
+    }
+
+    return `${trimSqBrackets(step)}`;
+  };
+
+  const getOtherLine = (): string => {
+    const step = classicWowStep[questNameIdx];
+
+    if (actionLine === 'Set Hearth') {
+      return `at [S ${removeFirstWord(step)}]`;
+    } else if (actionLine === 'Hearth') {
+      return `to [H ${removeFirstWord(step)}]`;
+    } else if (actionLine === 'Fly') {
+      return `to [F ${removeFirstWord(step)}]`;
+    } else if (actionLine === 'Get Flight Path') {
+      return `at [P ${removeFirstWord(step)}]`;
+    } else if (actionLine === 'Grind') {
+      return getGrindLine();
+    }
+    return `${trimSqBrackets(step)}`;
+  };
+
   const getQuestLine = (): string => {
     const questKey = questKeys[actionLine];
     if (typeof questKey === 'undefined') {
-      return `${trimSqBrackets(classicWowStep[questNameIdx])}`;
-    } else {
-      const questId = trimSqBrackets(classicWowStep[questIdIdx]);
-      if (questId !== '') {
-        const item =
-          actionLine === 'Accept Item Quest'
-            ? `(Item: ${trimSqBrackets(classicWowStep[npcName])})`
-            : '';
-        return `[Q${questKey}${questId}] ${item}`;
-      } else {
-        return `${trimSqBrackets(classicWowStep[questNameIdx])}`;
-      }
+      return getOtherLine();
     }
+
+    const questId = trimSqBrackets(classicWowStep[questIdIdx]);
+    if (questId !== '') {
+      const item = ['Accept Item Quest', 'Accept Item Quest*'].includes(actionLine)
+        ? `(Item: ${trimSqBrackets(classicWowStep[npcName])})`
+        : '';
+      return `[Q${questKey}${questId}] ${item}`;
+    } else {
+      return `${trimSqBrackets(classicWowStep[questNameIdx])}`;
+    }
+  };
+
+  const getStepIcon = (): string => {
+    if (actionLine === 'Vendor') {
+      return '[V]';
+    } else if (actionLine === 'Repair') {
+      return '[R]';
+    } else if (actionLine === 'Vendor + Repair') {
+      return '[V][R]';
+    } else if (actionLine === 'Train') {
+      return '[T]';
+    }
+    return '';
   };
 
   return [
     actionLine,
+    getStepIcon(),
     getQuestLine(),
     getAmount(),
     getNpc(),
     getObjective(),
-    hearth(),
     coordsLine(),
     xpLine,
     getNotes(),

--- a/src/guidelime.ts
+++ b/src/guidelime.ts
@@ -3,10 +3,11 @@ import * as ClassicWow from './classicwow';
 
 export type GuidelimeGuide = { [partName: string]: Array<string> };
 
+const capitalize = (str: string): string =>
+  str.charAt(0).toUpperCase() + str.substring(1).toLowerCase();
+
 export function getGuideTitle(wowRace: string, wowClass: string): string {
-  const wowRaceCapital = wowRace.charAt(0).toUpperCase() + wowRace.substring(1).toLowerCase();
-  const wowClassCapital = wowClass.charAt(0).toUpperCase() + wowClass.substring(1).toLowerCase();
-  return wowRaceCapital + wowClassCapital;
+  return capitalize(wowRace) + capitalize(wowClass);
 }
 
 export function generateGuide(wowRace: string, wowClass: string): GuidelimeGuide {
@@ -16,9 +17,9 @@ export function generateGuide(wowRace: string, wowClass: string): GuidelimeGuide
     const footer = `]], 'Guidelime_${getGuideTitle(wowRace, wowClass)}')`;
     return Object.keys(levelingSteps).reduce((parts, levelBracket, i, levelBrackets) => {
       const nextLevelBracket = levelBrackets[i + 1];
-      const titles = [`[N ${levelBracket} classicwow.live ${wowRace} ${wowClass}]`];
+      const titles = [`[GA ${capitalize(wowRace)},${capitalize(wowClass)}]`, `[N ${levelBracket}]`];
       if (typeof nextLevelBracket !== 'undefined') {
-        titles.push(`[NX ${nextLevelBracket} classicwow.live ${wowRace} ${wowClass}]`);
+        titles.push(`[NX ${nextLevelBracket}]`);
       }
       const steps = [
         header,


### PR DESCRIPTION
specifically:
- npc or interactable item names for further action types including quest progress steps,
- quantites for more action types (crafting, disenchanting, keeping items in invent)
- guidelime recognised grind, fly, get flight path, vendor and repair actions  

also includes:
- add race/class restriction to header
- coordinates are now all the same format