### PR TITLE
[Bugfix] - Tauren/Undead have starting zone/faction zone overlap. For…

### DIFF
--- a/src/classicwow.ts
+++ b/src/classicwow.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 export type LevelingData = { [section: string]: { [step: string]: Array<Array<string>> } };
+export type StepsByLevel = { [level: string]: Array<Array<string>> };
 
 const raceZoneFaction = {
   undead: ['tirisfal', 'horde'],
@@ -56,21 +57,11 @@ function loadResource(fileName: string): string {
   return fs.readFileSync(__dirname + '/resources/' + fileName, 'utf-8');
 }
 
-function appendLevelingData(first: LevelingData, second: LevelingData): LevelingData {
-  const finalSection = Object.keys(first).length;
-  Object.keys(second).forEach(sectionNumber => {
-    const steps = second[sectionNumber];
-    first[finalSection + Number(sectionNumber)] = steps;
-  });
-  return first;
-}
-
-function loadLevelingData(wowRace: string): LevelingData {
+function loadLevelingData(wowRace: string, startingZone: boolean): LevelingData {
   const [startZoneFile, factionFile] = getFileNames(wowRace);
-  const startZoneLevelingData = JSON.parse(loadResource(startZoneFile));
-  const factionLevelingData = JSON.parse(loadResource(factionFile));
-  const levelingData = appendLevelingData(startZoneLevelingData, factionLevelingData);
-  return levelingData;
+  return startingZone
+    ? JSON.parse(loadResource(startZoneFile))
+    : JSON.parse(loadResource(factionFile));
 }
 
 function filterSteps(
@@ -99,17 +90,17 @@ function filterSteps(
  * guides into a friendlier structure where steps are sectioned
  * by level.
  *
- * @param wowRace the wow race to parse steps for
+ * @param levelingData the parsed classic.wow json data
  * @param wowClass the wow class to parse steps for
- * @returns A map where keys are the level brackets and values are an array of steps.
+ * @param wowRace the wow race to parse steps for
+ * @returns A map where keys are the level and values are an array of steps for that level.
  */
-export function getLevelingSteps(
-  wowRace: string,
-  wowClass: string
-): { [bracket: string]: Array<Array<string>> } {
-  const levelingData = loadLevelingData(wowRace);
-
-  const stepsByLevel: { [level: string]: Array<Array<string>> } = {};
+function levelingStepsByZone(
+  levelingData: LevelingData,
+  wowClass: string,
+  wowRace: string
+): StepsByLevel {
+  const stepsByLevel: StepsByLevel = {};
   let substepsInLevel = [];
   Object.values(levelingData).forEach(steps => {
     Object.values(steps).forEach(step => {
@@ -123,21 +114,53 @@ export function getLevelingSteps(
       });
     });
   });
+  return stepsByLevel;
+}
+
+/**
+ * Converts the default section/steps structure of the classic.wow
+ * guides into a friendlier structure where steps are sectioned
+ * by level.
+ *
+ * @param wowRace the wow race to parse steps for
+ * @param wowClass the wow class to parse steps for
+ * @returns A map where keys are the level brackets and values are an array of steps.
+ */
+export function getLevelingSteps(
+  wowRace: string,
+  wowClass: string
+): { [bracket: string]: Array<Array<string>> } {
+  const startingLevelingData = loadLevelingData(wowRace, true);
+  const startingStepsByLevel = levelingStepsByZone(startingLevelingData, wowClass, wowRace);
 
   const bracketedSteps = {};
-  let startLevel = '1';
-  let endLevel = '0';
+  let startingZoneStartLevel = '1';
+  const startingZoneEndLevel = Object.keys(startingStepsByLevel).length.toString();
+  let bracketEndLevel = '0';
   let substeps = [];
-  Object.keys(stepsByLevel).forEach(level => {
-    const steps = stepsByLevel[level];
+  Object.keys(startingStepsByLevel).forEach(level => {
+    const steps = startingStepsByLevel[level];
     substeps = substeps.concat(steps);
-    if (substeps.length > 300 || level === '59') {
-      endLevel = (Number(level) + 1).toString();
-      bracketedSteps[`${startLevel}-${endLevel}`] = substeps;
-      startLevel = endLevel;
+    if (substeps.length > 300 || level === startingZoneEndLevel) {
+      bracketEndLevel = (Number(level) + 1).toString();
+      bracketedSteps[`${startingZoneStartLevel}-${bracketEndLevel}`] = substeps;
+      startingZoneStartLevel = bracketEndLevel;
       substeps = [];
     }
   });
 
+  const factionLevelingData = loadLevelingData(wowRace, false);
+  const factionStepsByLevel = levelingStepsByZone(factionLevelingData, wowClass, wowRace);
+  let factionZoneStartingLevel = Object.keys(factionStepsByLevel)[0];
+  Object.keys(factionStepsByLevel).forEach(level => {
+    const steps = factionStepsByLevel[level];
+    substeps = substeps.concat(steps);
+    if (substeps.length > 300 || level === '59') {
+      bracketEndLevel = (Number(level) + 1).toString();
+      bracketedSteps[`${factionZoneStartingLevel}-${bracketEndLevel}`] = substeps;
+      factionZoneStartingLevel = bracketEndLevel;
+      substeps = [];
+    }
+  });
   return bracketedSteps;
 }


### PR DESCRIPTION
… undead at least this overwrote level 12 starting zone steps with the level 12 Horde faction steps.

I noticed a lot of steps were missing on UndeadWarlock, so I looked into and noticed horde faction was overriding the tirisfal.json 'DING 12' because both json's had a 'DING 12'
So I basically updated it so that starting zone/ faction zone always create a new set of brackets, to make sure there's no overlap.

Sorry if I messed anything up, I'm a java dev just breaking into javascript stuff